### PR TITLE
Custom scalar support

### DIFF
--- a/packages/compiler/src/compiler.js
+++ b/packages/compiler/src/compiler.js
@@ -143,7 +143,7 @@ function generateEnumTypesFile({ src }, ast) {
   }
 }
 
-function generateTypeFiles({include, exclude, src}, schemaAst) {
+function generateTypeFiles({include, exclude, src, insert=""}, schemaAst) {
   console.log('analyzing reason files...');
   let typeMap = createTypeMap(schemaAst);
 
@@ -167,12 +167,12 @@ function generateTypeFiles({include, exclude, src}, schemaAst) {
   console.log('generating type files...');
   const DEST_DIR = path.join(src, '.reasonql');
   nodes.forEach(node => {
-    generateTypeFile(DEST_DIR, node, typeMap);
+    generateTypeFile(DEST_DIR, node, typeMap, insert);
   })
 }
 
-function generateTypeFile(DEST_DIR, node, typeMap) {
-  let code = generateReasonCode(node, typeMap);
+function generateTypeFile(DEST_DIR, node, typeMap, insert) {
+  let code = `${insert}\n${generateReasonCode(node, typeMap)}`;
   fs.writeFileSync(path.join(DEST_DIR, `${node.fileName}.re`), code);
 }
 

--- a/packages/compiler/src/graphql-to-reason/codec.js
+++ b/packages/compiler/src/graphql-to-reason/codec.js
@@ -25,7 +25,7 @@ var ${functionName} = function (res) {
 ${type.fields.map(field => {
   let varname = `res.${field.name}`;
 
-  if(field.scalar) {
+  if(field.isBuiltinScalar) {
     return `    ${varname},`;
   } else if(field.fragment) {
     let [component, typeName] = field.type.split('.');

--- a/packages/compiler/src/graphql-to-reason/node.js
+++ b/packages/compiler/src/graphql-to-reason/node.js
@@ -2,11 +2,11 @@ const {parse} = require('graphql');
 const {makeTypeList, argumentTypes} = require('./type');
 const {generateDecoder} = require('./codec');
 
-function generateNodes(gqlCodes, typeMap) {
+function generateNodes(gqlCodes, typeMap, operationRoots) {
   let nodes = gqlCodes.map(code => {
     let ast = parse(code.template);
     let queryRoot = ast.definitions[0];
-
+    
     let name = queryRoot.name.value;
     let isFragment = queryRoot.kind == "FragmentDefinition";
     
@@ -15,9 +15,9 @@ function generateNodes(gqlCodes, typeMap) {
       : name;
     let typeList = isFragment
       ? ast.definitions
-        .map(def => makeTypeList(def, isFragment, typeMap))
+        .map(def => makeTypeList(def, operationRoots, isFragment, typeMap))
         .reduce((prev, current) => [...prev, ...current], [])
-      : makeTypeList(queryRoot, isFragment, typeMap);
+      : makeTypeList(queryRoot, operationRoots, isFragment, typeMap);
 
     return {
       code: code.template.trim(),

--- a/packages/compiler/src/graphql-to-reason/type.js
+++ b/packages/compiler/src/graphql-to-reason/type.js
@@ -174,17 +174,21 @@ function argumentTypes(args, typeMap) {
   return list;
 }
 
+let scalarTypes = {
+  "ID": "string",
+  "String": "string",
+  "Boolean": "bool",
+  "Int": "int",
+  "Float": "float",
+};
+
+function isScalar(type) {
+  return type in scalarTypes;
+}
+
 function getValidTypeName(types, unconflictedNames, typeName) {
   if(isScalar(typeName)) {
-    let typeNames = {
-      "ID": "string",
-      "String": "string",
-      "Boolean": "bool",
-      "Int": "int",
-      "Float": "float",
-    };
-
-    return typeNames[typeName];
+    return scalarTypes[typeName];
   } else if(isFragmentTypeName(typeName)) {
     return typeName;
   } else if(typeName.includes('#')) { // For fragment type definition.
@@ -203,11 +207,6 @@ function getValidTypeName(types, unconflictedNames, typeName) {
 
     return lowerTheFirstCharacter(name);
   }
-}
-
-function isScalar(type) {
-  let scalarTypes = ["ID", "String", "Int", "Float", "Boolean"];
-  return scalarTypes.includes(type);
 }
 
 function isRootName(type) {
@@ -261,8 +260,15 @@ function decodeType(name, field) {
 }
 
 function createTypeMap(ast) {
-  let types = {}
+  let types = {};
   let enums = [];
+  console.log(JSON.stringify(ast));
+  ast.definitions
+  .filter(def => def.kind == "ScalarTypeDefinition")
+  .forEach(def => {
+    scalarTypes[def.name.value] = "string"
+  });
+
   ast.definitions
   .filter(def => def.kind == "EnumTypeDefinition")
   .forEach(def => {

--- a/packages/compiler/src/graphql-to-reason/type.js
+++ b/packages/compiler/src/graphql-to-reason/type.js
@@ -66,7 +66,8 @@ function extractType(types, ast, selectionNames, typeMap, currentType, userDefin
           type: isScalar(typeName)
             ? typeName
             : [...selectionNames, name, typeName].join('_'),
-          scalar: isScalar(typeName)
+          scalar: isScalar(typeName),
+          isBuiltinScalar: isBuiltinScalar(typeName)
         }
       }
     }
@@ -182,6 +183,16 @@ let scalarTypes = {
   "Float": "float",
 };
 
+function isBuiltinScalar(type) {
+  return type in {
+    "ID": "string",
+    "String": "string",
+    "Boolean": "bool",
+    "Int": "int",
+    "Float": "float",
+  };
+}
+
 function isScalar(type) {
   return type in scalarTypes;
 }
@@ -262,11 +273,10 @@ function decodeType(name, field) {
 function createTypeMap(ast) {
   let types = {};
   let enums = [];
-  console.log(JSON.stringify(ast));
   ast.definitions
   .filter(def => def.kind == "ScalarTypeDefinition")
   .forEach(def => {
-    scalarTypes[def.name.value] = "string"
+    scalarTypes[def.name.value] = lowerTheFirstCharacter(def.name.value);
   });
 
   ast.definitions

--- a/packages/compiler/src/graphql-to-reason/type.js
+++ b/packages/compiler/src/graphql-to-reason/type.js
@@ -1,26 +1,16 @@
 const { lowerTheFirstCharacter } = require('./util');
 
-function makeTypeList(queryRoot, isFragment, typeMap) {
+function makeTypeList(queryRoot, roots, isFragment, typeMap) {
   let types = {};
   let rootType = isFragment 
     ? queryRoot.typeCondition.name.value
-    : operationToTypeName(queryRoot.operation);
+    : roots[queryRoot.operation];
   extractType(types, queryRoot, [], typeMap, rootType);
 
   let typeList = childTypes(types, types[rootType]);
   typeList = validTypeNames(types, typeList);
 
   return typeList;
-}
-
-function operationToTypeName(operation) {
-  let names = {
-    "query": "Query",
-    "mutation": "Mutation",
-    "subscription": "Subscription",
-  };
-
-  return names[operation];
 }
 
 function extractType(types, ast, selectionNames, typeMap, currentType, userDefinedTypeName) {
@@ -71,7 +61,7 @@ function extractType(types, ast, selectionNames, typeMap, currentType, userDefin
         }
       }
     }
-  })
+  });
   
   let name = [...selectionNames, currentType].join('_');
   types[name] = {

--- a/packages/compiler/src/graphql-to-reason/type.js
+++ b/packages/compiler/src/graphql-to-reason/type.js
@@ -57,7 +57,7 @@ function extractType(types, ast, selectionNames, typeMap, currentType, userDefin
             ? typeName
             : [...selectionNames, name, typeName].join('_'),
           scalar: isScalar(typeName),
-          isBuiltinScalar: isBuiltinScalar(typeName)
+          isBuiltinScalar: isBuiltinScalar(typeName),
         }
       }
     }
@@ -73,6 +73,7 @@ function extractType(types, ast, selectionNames, typeMap, currentType, userDefin
       : currentType,
     fields,
     userDefinedTypeName,
+    isRootType: ast.kind == "OperationDefinition",
   }
 }
 
@@ -197,22 +198,17 @@ function getValidTypeName(types, unconflictedNames, typeName) {
   } else if(types['variablesType']) {
     return lowerTheFirstCharacter(typeName);
   } else {
-    let {selectionName, userDefinedTypeName} = types[typeName];
+    let {selectionName, userDefinedTypeName, isRootType=false} = types[typeName];
     let name = 
       userDefinedTypeName 
         ? userDefinedTypeName
         : unconflictedNames.includes(selectionName)
           ? selectionName
           : typeName
-    name = isRootName(name) ? "queryResult" : name;
+    name = isRootType ? "queryResult" : name;
 
     return lowerTheFirstCharacter(name);
   }
-}
-
-function isRootName(type) {
-  let names = ["Query", "Mutation", "Subscription"];
-  return names.includes(type);
 }
 
 function isFragmentTypeName(type) {

--- a/packages/compiler/src/tagFinder.js
+++ b/packages/compiler/src/tagFinder.js
@@ -1,7 +1,7 @@
 const lineColumn = require('line-column');
 
 function findTags(text) {
-  let re = /gql\({\|([\s\S]*?)\|}\)/g;
+  let re = /gql\(\s*{\|([\s\S]*?)\|}\)/g;
 
   let tags = [];
   let result;

--- a/packages/compiler/src/tagFinder.js
+++ b/packages/compiler/src/tagFinder.js
@@ -1,7 +1,7 @@
 const lineColumn = require('line-column');
 
 function findTags(text) {
-  let re = /gql\(\s*{\|([\s\S]*?)\|}\)/g;
+  let re = /gql\(\s*{\|([\s\S]*?)\|}\s*\)/g;
 
   let tags = [];
   let result;

--- a/packages/core/src/ReasonQL.re
+++ b/packages/core/src/ReasonQL.re
@@ -44,13 +44,13 @@ module MakeRequest = (Q: Query, C: Client) => {
 
   [@bs.val]external fetch: (string, Js.Json.t) => Js.Promise.t(response) = "";
 
-  let send: Q.variablesType => Js.Promise.t(apolloResultJs) = vars => {
+  let send = (~headers=Js.Obj.empty(), ~vars: Q.variablesType): Js.Promise.t(apolloResultJs) => {
     open Js.Promise;
     fetch(C.url, Obj.magic({
       "method": "POST",
-      "headers": {
-        "Content-Type": "application/json",
-      },
+      "headers": Js.Obj.assign({
+        "Content-Type": "application/json"
+      }, headers),
       "body": Js.Json.stringify(Obj.magic({
         "query": Q.query,
         "variables": Q.encodeVariables(vars),

--- a/snippets/custom-scalar/client/.gitignore
+++ b/snippets/custom-scalar/client/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+.merlin
+.bsb.lock
+npm-debug.log
+/lib/bs/
+/node_modules/

--- a/snippets/custom-scalar/client/bsconfig.json
+++ b/snippets/custom-scalar/client/bsconfig.json
@@ -1,0 +1,21 @@
+{
+  "name": "hello-world-client",
+  "reason": {
+    "react-jsx": 2
+  },
+  "sources": {
+    "dir" : "src",
+    "subdirs" : true
+  },
+  "package-specs": [{
+    "module": "commonjs",
+    "in-source": true
+  }],
+  "suffix": ".bs.js",
+  "namespace": true,
+  "bs-dependencies": [
+    "@reasonql/core",
+    "reason-react"
+  ],
+  "refmt": 3
+}

--- a/snippets/custom-scalar/client/package.json
+++ b/snippets/custom-scalar/client/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "hello-world-client",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "bsb -make-world",
+    "start": "bsb -make-world -w",
+    "clean": "bsb -clean-world",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "reasonql": "reasonql-compiler",
+    "webpack": "webpack -w",
+    "webpack:production": "NODE_ENV=production webpack",
+    "server": "webpack-dev-server"
+  },
+  "keywords": [
+    "BuckleScript"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@reasonql/core": "^0.1.4",
+    "react": "^16.8.3",
+    "react-dom": "^16.8.3",
+    "reason-react": "^0.5.3"
+  },
+  "devDependencies": {
+    "@reasonql/compiler": "^0.1.8",
+    "bs-platform": "^4.0.18",
+    "html-webpack-plugin": "^3.2.0",
+    "webpack": "^4.0.1",
+    "webpack-cli": "^3.1.1",
+    "webpack-dev-server": "^3.1.8"
+  }
+}

--- a/snippets/custom-scalar/client/package.json
+++ b/snippets/custom-scalar/client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hello-world-client",
+  "name": "custom-scalar-client",
   "version": "0.1.0",
   "scripts": {
     "build": "bsb -make-world",

--- a/snippets/custom-scalar/client/reasonql.config.js
+++ b/snippets/custom-scalar/client/reasonql.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  schema: "../server/src/schema.js",
+}

--- a/snippets/custom-scalar/client/reasonql.config.js
+++ b/snippets/custom-scalar/client/reasonql.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   schema: "../server/src/schema.js",
+  insert: "include CustomTypes;"
 }

--- a/snippets/custom-scalar/client/src/App.re
+++ b/snippets/custom-scalar/client/src/App.re
@@ -1,3 +1,5 @@
+open CustomTypes;
+
 type queryStatus = 
   | Loading
   | Error
@@ -22,6 +24,11 @@ let query = ReasonQL.gql({|
     }
   }
 |})
+
+let set_default = (default: 'a, opt: option('a)) => switch(opt) {
+| Some(v) => v
+| None => default
+};
 
 module Request = ReasonQL.MakeRequest(AppQuery, {
   let url = "http://localhost:4000";
@@ -53,12 +60,18 @@ let make = (_children) => {
     | Error => { ReasonReact.string("Error") }
     | Data => { 
       let data = Belt.Option.getExn(self.state.data);
-      
-      switch(data.hello) {
-      | Some(hello) => { ReasonReact.string(hello.message) }
-      | None => { ReasonReact.string("message not found") }
-      }
+      <div>
+      {data.accounts
+        |> Array.mapi((i: int, account: AppQuery.accounts) => 
+        <div key={i |> string_of_int}>
+          <li>{account.id |> uuidToString |> ReasonReact.string}</li>
+          <li>{account.name |> set_default("No Name") |> ReasonReact.string}</li>
+          <li>{account.updated_at |> Js.Date.toDateString |> ReasonReact.string}</li>
+        </div>)
+        |> ReasonReact.array}
+      </div>
     }
     }
   }
 }
+

--- a/snippets/custom-scalar/client/src/App.re
+++ b/snippets/custom-scalar/client/src/App.re
@@ -1,0 +1,64 @@
+type queryStatus = 
+  | Loading
+  | Error
+  | Data
+
+type state = {
+  status: queryStatus,
+  data: option(AppQuery.queryResult),
+}
+
+type action = 
+  | Fetched(AppQuery.queryResult)
+
+let component = ReasonReact.reducerComponent("App");
+
+let query = ReasonQL.gql({|
+  query AppQuery {
+    accounts {
+      id
+      name
+      updated_at
+    }
+  }
+|})
+
+module Request = ReasonQL.MakeRequest(AppQuery, {
+  let url = "http://localhost:4000";
+});
+
+let make = (_children) => {
+  ...component,
+  initialState: () => {
+    status: Loading,
+    data: None,
+  },
+
+  didMount: self => {
+    Request.send(Js.Dict.empty())
+    ->Request.finished(data => {
+      self.send(Fetched(data));
+    })
+  },
+
+  reducer: (action, _state) => {
+    switch(action) {
+    | Fetched(data) => ReasonReact.Update({ status: Data, data: Some(data) })
+    }
+  },
+
+  render: self => {
+    switch(self.state.status) {
+    | Loading => { ReasonReact.string("Loading") }
+    | Error => { ReasonReact.string("Error") }
+    | Data => { 
+      let data = Belt.Option.getExn(self.state.data);
+      
+      switch(data.hello) {
+      | Some(hello) => { ReasonReact.string(hello.message) }
+      | None => { ReasonReact.string("message not found") }
+      }
+    }
+    }
+  }
+}

--- a/snippets/custom-scalar/client/src/CustomTypes.re
+++ b/snippets/custom-scalar/client/src/CustomTypes.re
@@ -1,0 +1,22 @@
+type timestamptz = Js.Date.t;
+
+let decodeTimestamptz = Js.Date.fromString;
+
+let encodeTimestamptz = Js.Date.toISOString;
+
+type uuid;
+
+[%%raw {|
+
+function decodeUuid (val) {
+  return val;
+}
+
+function encodeUuid (val) {
+  return val;
+}
+|}];
+
+let decodeUuid: Js.Json.t => uuid = [%raw {|a => a|}];
+let encodeUuid: uuid => Js.Json.t = [%raw {|a => a|}];
+external uuidToString: uuid => string = "%identity";

--- a/snippets/custom-scalar/client/src/Index.re
+++ b/snippets/custom-scalar/client/src/Index.re
@@ -1,0 +1,1 @@
+ReactDOMRe.renderToElementWithId(<App />, "root");

--- a/snippets/custom-scalar/client/src/index.html
+++ b/snippets/custom-scalar/client/src/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>ReasonReact Examples</title>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script src="Index.js"></script>
+</body>
+</html>

--- a/snippets/custom-scalar/client/webpack.config.js
+++ b/snippets/custom-scalar/client/webpack.config.js
@@ -1,0 +1,28 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const outputDir = path.join(__dirname, 'build/');
+
+const isProd = process.env.NODE_ENV === 'production';
+
+module.exports = {
+  entry: './src/Index.bs.js',
+  mode: isProd ? 'production' : 'development',
+  output: {
+    path: outputDir,
+    filename: 'Index.js'
+  },
+  module: {
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: 'src/index.html',
+      inject: false
+    })
+  ],
+  devServer: {
+    compress: true,
+    contentBase: outputDir,
+    port: process.env.PORT || 8000,
+    historyApiFallback: true
+  }
+};

--- a/snippets/custom-scalar/server/package.json
+++ b/snippets/custom-scalar/server/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "hello-world-server",
+  "version": "0.1.0",
+  "scripts": {
+    "start": "node ./src/index.js"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "apollo-datasource": "^0.3.1",
+    "apollo-datasource-rest": "^0.3.2",
+    "apollo-server": "^2.4.6",
+    "dotenv": "^6.1.0",
+    "graphql": "^14.1.1",
+    "graphql-tag": "^2.10.1"
+  },
+  "devDependencies": {
+    "apollo": "^2.1.8",
+    "apollo-link": "^1.2.3",
+    "apollo-link-http": "^1.5.11",
+    "html-webpack-plugin": "^3.2.0",
+    "webpack": "^4.0.1",
+    "webpack-cli": "^3.1.1",
+    "webpack-dev-server": "^3.1.8"
+  }
+}

--- a/snippets/custom-scalar/server/package.json
+++ b/snippets/custom-scalar/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hello-world-server",
+  "name": "custom-scalar-server",
   "version": "0.1.0",
   "scripts": {
     "start": "node ./src/index.js"

--- a/snippets/custom-scalar/server/src/index.js
+++ b/snippets/custom-scalar/server/src/index.js
@@ -1,0 +1,17 @@
+const { ApolloServer } = require('apollo-server');
+
+const typeDefs = require('./schema');
+const resolvers = require('./resolvers');
+
+// Set up Apollo Server
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+});
+
+// Start our server if we're not in a test env.
+// if we're in a test env, we'll manually start it in a test
+if (process.env.NODE_ENV !== 'test')
+  server
+    .listen({ port: 4000 })
+    .then(({ url }) => console.log(`🚀 app running at ${url}`));

--- a/snippets/custom-scalar/server/src/resolvers.js
+++ b/snippets/custom-scalar/server/src/resolvers.js
@@ -1,0 +1,10 @@
+module.exports = {
+  Query: {
+    hello: function(_, _, _) {
+      return {
+        id: "1234",
+        message: "Hello, GraphQL World!"
+      };
+    },
+  }
+}

--- a/snippets/custom-scalar/server/src/resolvers.js
+++ b/snippets/custom-scalar/server/src/resolvers.js
@@ -1,10 +1,18 @@
 module.exports = {
   Query: {
-    hello: function(_, _, _) {
-      return {
-        id: "1234",
-        message: "Hello, GraphQL World!"
-      };
+    accounts: function (_, _, _) {
+      return [{
+        id: "72520fc6-0387-4f71-807d-c22c81c86dfb",
+        name: "Me",
+        timezone: "UTC+8",
+        updated_at: new Date()
+      }, {
+        id: "5aabe3c1-e1cf-41cf-9659-73a878380b8f",
+        name: null,
+        timezone: "UTC+8",
+        updated_at: new Date()
+      },
+      ];
     },
   }
 }

--- a/snippets/custom-scalar/server/src/schema.js
+++ b/snippets/custom-scalar/server/src/schema.js
@@ -1,0 +1,23 @@
+const { gql } = require('apollo-server');
+
+const typeDefs = gql`
+schema {
+  query: Query
+}
+
+scalar uuid
+scalar timestamptz
+
+type accounts {
+  id: uuid!
+  name: String
+  timezone: String!
+  updated_at: timestamptz!
+}
+
+type Query {
+  accounts: [accounts!]!
+}
+`
+
+module.exports = typeDefs;

--- a/snippets/custom-scalar/server/src/schema.js
+++ b/snippets/custom-scalar/server/src/schema.js
@@ -2,7 +2,7 @@ const { gql } = require('apollo-server');
 
 const typeDefs = gql`
 schema {
-  query: Query
+  query: query_root
 }
 
 scalar uuid
@@ -15,7 +15,7 @@ type accounts {
   updated_at: timestamptz!
 }
 
-type Query {
+type query_root {
   accounts: [accounts!]!
 }
 `


### PR DESCRIPTION
read custom scalar from ast.
wrap decode<TypeName>/encode<TypeName> around decode/encode.
config file insert field to add anything to generated file.
like insert: "include CustomTypes;"
CustomTypes.re includes the decode<TypeName>/encode<TypeName> for the types.

see snippets/custom-scalar for example