### PR TITLE
Return type

### DIFF
--- a/packages/compiler/src/graphql-to-reason/reason.js
+++ b/packages/compiler/src/graphql-to-reason/reason.js
@@ -100,8 +100,17 @@ ${
   }).join('\n\n');
 }
 
+let scalarTypes = {
+  "id": "string",
+  "string": "string",
+  "boolean": "bool",
+  "int": "int",
+  "float": "float",
+  "smallint": "int",
+};
+
 function wrapTypeName(field) {
-  let typeName = field.typeName;
+  let typeName = scalarTypes[field.typeName] || field.typeName;
 
   typeName = field.contentOption
     ? `option(${typeName})`

--- a/packages/compiler/src/tagFinder.js
+++ b/packages/compiler/src/tagFinder.js
@@ -1,12 +1,12 @@
 const lineColumn = require('line-column');
 
 function findTags(text) {
-  let re = /gql\(\s*{\|([\s\S]*?)\|}\s*\)/g;
+  let re = /gql\(\s*{\|([\s\S]*?)\|}[\s,]*\)/g;
 
   let tags = [];
   let result;
   while ((result = re.exec(text)) !== null) {
-    let {line, col: column} = lineColumn(text, result.index);
+    let { line, col: column } = lineColumn(text, result.index);
     tags.push({
       template: result[1],
       sourceLocationOffset: {

--- a/packages/core/src/ReasonQL.re
+++ b/packages/core/src/ReasonQL.re
@@ -17,7 +17,10 @@ let decodeError: array(apolloErrorJs) => array(apolloError) =
     |> Array.map(err => {message: err##message, extensions: err##extensions});
   };
 
-module type Client = {let url: string;};
+module type Client = {
+  let url: string;
+  let headers: Js.t({..});
+};
 
 module type Query = {
   let query: string;
@@ -53,7 +56,10 @@ module MakeRequest = (Q: Query, C: Client) => {
         Obj.magic({
           "method": "POST",
           "headers":
-            Js.Obj.assign({"Content-Type": "application/json"}, headers),
+            Js.Obj.assign(
+              Js.Obj.assign({"Content-Type": "application/json"}, C.headers),
+              headers,
+            ),
           "body":
             Js.Json.stringify(
               Obj.magic({

--- a/packages/core/src/ReasonQL.re
+++ b/packages/core/src/ReasonQL.re
@@ -67,25 +67,21 @@ module MakeRequest = (Q: Query, C: Client) => {
     );
   };
 
-  let finished: (Js.Promise.t(apolloResultJs), Q.queryResult => unit) => unit =
-    (promise, f) => {
+  let finished: Js.Promise.t(apolloResultJs) => Js.Promise.t(Q.queryResult) =
+    promise => {
       Js.Promise.(
         promise
         |> then_(json => {
              let data = Q.decodeQueryResult(json##data);
-             resolve(f(data));
+             resolve(data);
            })
-        |> ignore
       );
     };
 
   let finishedWithError:
-    (
-      Js.Promise.t(apolloResultJs),
-      (Q.queryResult, option(array(apolloError))) => unit
-    ) =>
-    unit =
-    (promise, f) => {
+    Js.Promise.t(apolloResultJs) =>
+    Js.Promise.t((Q.queryResult, option(array(apolloError)))) =
+    promise => {
       Js.Promise.(
         promise
         |> then_(json => {
@@ -95,10 +91,8 @@ module MakeRequest = (Q: Query, C: Client) => {
                | Some(errors) => Some(decodeError(errors))
                | None => None
                };
-
-             resolve(f(data, errors));
+             resolve((data, errors));
            })
-        |> ignore
       );
     };
 };

--- a/packages/core/src/ReasonQL.re
+++ b/packages/core/src/ReasonQL.re
@@ -86,17 +86,18 @@ module MakeRequest = (Q: Query, C: Client) => {
 
   let finishedWithError:
     Js.Promise.t(apolloResultJs) =>
-    Js.Promise.t((Q.queryResult, option(array(apolloError)))) =
+    Js.Promise.t((option(Q.queryResult), option(array(apolloError)))) =
     promise => {
       Js.Promise.(
         promise
         |> then_(json => {
-             let data = Q.decodeQueryResult(json##data);
              let errors =
                switch (json##errors) {
                | Some(errors) => Some(decodeError(errors))
                | None => None
                };
+             let data =
+               errors == None ? Some(Q.decodeQueryResult(json##data)) : None;
              resolve((data, errors));
            })
       );

--- a/packages/core/src/ReasonQL.re
+++ b/packages/core/src/ReasonQL.re
@@ -1,93 +1,104 @@
 let gql = code => code;
 
-type apolloErrorJs = Js.t({.
-  message: string,
-  extensions: Js.Json.t,
-})
+type apolloErrorJs = {
+  .
+  "message": string,
+  "extensions": Js.Json.t,
+};
 
 type apolloError = {
   message: string,
   extensions: Js.Json.t,
 };
 
-let decodeError: array(apolloErrorJs) => array(apolloError) 
-= errors => {
-  errors |> Array.map(err => {
-    message: err##message,
-    extensions: err##extensions,
-  })
-};
+let decodeError: array(apolloErrorJs) => array(apolloError) =
+  errors => {
+    errors
+    |> Array.map(err => {message: err##message, extensions: err##extensions});
+  };
 
-module type Client = {
-  let url: string;
-};
+module type Client = {let url: string;};
 
 module type Query = {
   let query: string;
-  
+
   type variablesType;
   let encodeVariables: variablesType => Js.Json.t;
-  
-  type queryResult
+
+  type queryResult;
   let decodeQueryResult: Js.Json.t => queryResult;
 };
 
 module MakeRequest = (Q: Query, C: Client) => {
-  type apolloResultJs = Js.t({.
-    data: Js.Json.t,
-    errors: option(array(apolloErrorJs)),
-  });
-
-  type response = Js.t({.
-    [@bs.meth] json: unit => Js.Promise.t(apolloResultJs),
-  });
-
-  [@bs.val]external fetch: (string, Js.Json.t) => Js.Promise.t(response) = "";
-
-  let send = (~headers=Js.Obj.empty(), ~vars: Q.variablesType): Js.Promise.t(apolloResultJs) => {
-    open Js.Promise;
-    fetch(C.url, Obj.magic({
-      "method": "POST",
-      "headers": Js.Obj.assign({
-        "Content-Type": "application/json"
-      }, headers),
-      "body": Js.Json.stringify(Obj.magic({
-        "query": Q.query,
-        "variables": Q.encodeVariables(vars),
-      }))
-    }))
-    |> then_((response:response) => {
-      response##json();
-    })
-  }
-
-  let finished: (Js.Promise.t(apolloResultJs), Q.queryResult => unit) => unit
-  = (promise, f) => {
-    open Js.Promise;
-
-    promise 
-    |> then_(json => {
-      let data = Q.decodeQueryResult(json##data);
-      resolve(f(data))
-    })
-    |> ignore;
+  type apolloResultJs = {
+    .
+    "data": Js.Json.t,
+    "errors": option(array(apolloErrorJs)),
   };
 
-  let finishedWithError: (Js.Promise.t(apolloResultJs), (Q.queryResult, option(array(apolloError))) => unit) => unit
-  = (promise, f) => {
-    open Js.Promise;
+  type response = {
+    .
+    [@bs.meth] "json": unit => Js.Promise.t(apolloResultJs),
+  };
 
-    promise 
-    |> then_(json => {
-      let data = Q.decodeQueryResult(json##data);
-      let errors = 
-        switch(json##errors) {
-        | Some(errors) => Some(decodeError(errors));
-        | None => None
-        }
-      
-      resolve(f(data, errors))
-    })
-    |> ignore;
-  }
-}
+  [@bs.val]
+  external fetch: (string, Js.Json.t) => Js.Promise.t(response) = "";
+
+  let send =
+      (~headers=Js.Obj.empty(), ~vars: Q.variablesType)
+      : Js.Promise.t(apolloResultJs) => {
+    Js.Promise.(
+      fetch(
+        C.url,
+        Obj.magic({
+          "method": "POST",
+          "headers":
+            Js.Obj.assign({"Content-Type": "application/json"}, headers),
+          "body":
+            Js.Json.stringify(
+              Obj.magic({
+                "query": Q.query,
+                "variables": Q.encodeVariables(vars),
+              }),
+            ),
+        }),
+      )
+      |> then_((response: response) => response##json())
+    );
+  };
+
+  let finished: (Js.Promise.t(apolloResultJs), Q.queryResult => unit) => unit =
+    (promise, f) => {
+      Js.Promise.(
+        promise
+        |> then_(json => {
+             let data = Q.decodeQueryResult(json##data);
+             resolve(f(data));
+           })
+        |> ignore
+      );
+    };
+
+  let finishedWithError:
+    (
+      Js.Promise.t(apolloResultJs),
+      (Q.queryResult, option(array(apolloError))) => unit
+    ) =>
+    unit =
+    (promise, f) => {
+      Js.Promise.(
+        promise
+        |> then_(json => {
+             let data = Q.decodeQueryResult(json##data);
+             let errors =
+               switch (json##errors) {
+               | Some(errors) => Some(decodeError(errors))
+               | None => None
+               };
+
+             resolve(f(data, errors));
+           })
+        |> ignore
+      );
+    };
+};

--- a/packages/core/src/Utils.re
+++ b/packages/core/src/Utils.re
@@ -1,0 +1,17 @@
+let set_default = (default: 'a, opt: option('a)) =>
+  switch (opt) {
+  | Some(v) => v
+  | None => default
+  };
+
+let (>>=) = (opt: option('a), fn: 'a => option('b)): option('b) =>
+  switch (opt) {
+  | Some(v) => fn(v)
+  | None => None
+  };
+
+let (-?>) = (opt: option('a), fn: 'a => 'b): option('b) =>
+  switch (opt) {
+  | Some(v) => Some(fn(v))
+  | None => None
+  };


### PR DESCRIPTION
changed finishedWithErrorPromise API to so that's easier to use.

let finishedWithErrorPromise:
    Js.Promise.t(apolloResultJs) =>
    Js.Promise.t(result(Q.queryResult, array(apolloError)))